### PR TITLE
DEV: Pass respect_plugin_enabled to add_to_serializer as keyword argument

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -199,7 +199,7 @@ after_initialize do
     )
   end
 
-  add_to_serializer(:post, :ratings, false) do
+  add_to_serializer(:post, :ratings, respect_plugin_enabled: false) do
     DiscourseRatings::Rating.serialize(object.ratings)
   end
 


### PR DESCRIPTION
### What is this change?

Passing the `respect_plugin_enabled` argument to `#add_to_serializer` as a positional argument is deprecated. It is now expected to be a keyword argument. This PR adds the keyword.