### PR TITLE
DEV: Refresh auto group in test

### DIFF
--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1,32 +1,33 @@
 # frozen_string_literal: true
 
-require_relative '../plugin_helper.rb'
+require_relative "../plugin_helper.rb"
 
 describe PostsController do
-  let(:rating_hash) { JSON.parse('[{"type":"pointers","value":"4", "pavilion": "yes"}]') }
-  let(:rating_none_type) { 'none' }
-  let(:rating_none_name) { 'None' }
+  let(:rating_hash) do
+    JSON.parse('[{"type":"pointers","value":"4", "pavilion": "yes"}]')
+  end
+  let(:rating_none_type) { "none" }
+  let(:rating_none_name) { "None" }
   fab!(:rating_category) { Fabricate(:category) }
-  fab!(:user) { sign_in(Fabricate(:user)) }
+  fab!(:user) { sign_in(Fabricate(:user, refresh_auto_groups: true)) }
   fab!(:rating_topic) { Fabricate(:topic, category: rating_category) }
   fab!(:rating_post) { Fabricate(:post, topic: rating_topic, user: user) }
   let(:none_rating_json) { '[{"type":"none","value":"4", "pavilion": "yes"}]' }
-  let(:multiple_rating_hash) { JSON.parse('[{"type":"pointers","value":"4", "pavilion": "yes"}, {"type":"handwriting","value":"3"}]') }
+  let(:multiple_rating_hash) do
+    JSON.parse(
+      '[{"type":"pointers","value":"4", "pavilion": "yes"}, {"type":"handwriting","value":"3"}]'
+    )
+  end
   let(:create_params) do
     {
-      raw: 'new body',
+      raw: "new body",
       ratings: none_rating_json,
       topic_id: rating_topic.id,
       user_id: user.id
     }
   end
   let(:update_params) do
-    {
-        post: {
-          raw: 'edited body',
-          ratings: none_rating_json,
-        }
-    }
+    { post: { raw: "edited body", ratings: none_rating_json } }
   end
   it "adds the the rating correctly" do
     SiteSetting.rating_enabled = true
@@ -35,9 +36,9 @@ describe PostsController do
     post "/posts.json", params: create_params
     expect(response.status).to eq(200)
 
-    post_id = JSON.parse(response.body)['id']
+    post_id = JSON.parse(response.body)["id"]
     post = Post.find(post_id)
-    expect(post.custom_fields['rating_none']).to be_present
+    expect(post.custom_fields["rating_none"]).to be_present
   end
 
   it "updates the rating correctly" do
@@ -50,6 +51,6 @@ describe PostsController do
     put "/posts/#{post.id}.json", params: update_params
     expect(response.status).to eq(200)
     post.reload
-    expect(post.custom_fields['rating_none']).to be_present
+    expect(post.custom_fields["rating_none"]).to be_present
   end
 end


### PR DESCRIPTION
Related: https://github.com/discourse/discourse/pull/24257

Due to changes in site settings related to trust level, we must now `refresh_auto_groups` when we fab users.