### PR TITLE
FIX: use proper action function

### DIFF
--- a/assets/javascripts/discourse/components/rating-destroy.js
+++ b/assets/javascripts/discourse/components/rating-destroy.js
@@ -1,4 +1,5 @@
 import Component from "@ember/component";
+import { action } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
 import Rating from "../models/rating";
 
@@ -10,26 +11,25 @@ export default Component.extend({
     return [categoryId, type].any((i) => !i);
   },
 
-  actions: {
-    destroyRatings() {
-      let data = {
-        category_id: this.categoryId,
-      };
+  @action
+  destroyRatings() {
+    let data = {
+      category_id: this.categoryId,
+    };
 
-      this.set("startingDestroy", true);
+    this.set("startingDestroy", true);
 
-      Rating.destroy(this.type, data)
-        .then((result) => {
-          if (result.success) {
-            this.set("destroyMessage", "admin.ratings.destroy.started");
-          } else {
-            this.set(
-              "destroyMessage",
-              "admin.ratings.error.destroy_failed_to_start"
-            );
-          }
-        })
-        .finally(() => this.set("startingDestroy", false));
-    },
+    Rating.destroy(this.type, data)
+      .then((result) => {
+        if (result.success) {
+          this.set("destroyMessage", "admin.ratings.destroy.started");
+        } else {
+          this.set(
+            "destroyMessage",
+            "admin.ratings.error.destroy_failed_to_start"
+          );
+        }
+      })
+      .finally(() => this.set("startingDestroy", false));
   },
 });

--- a/assets/javascripts/discourse/components/rating-migrate.js
+++ b/assets/javascripts/discourse/components/rating-migrate.js
@@ -1,4 +1,5 @@
 import Component from "@ember/component";
+import { action } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
 import Rating from "../models/rating";
 
@@ -15,28 +16,27 @@ export default Component.extend({
     );
   },
 
-  actions: {
-    migrate() {
-      let data = {
-        category_id: this.categoryId,
-        type: this.fromType,
-        new_type: this.toType,
-      };
+  @action
+  migrate() {
+    let data = {
+      category_id: this.categoryId,
+      type: this.fromType,
+      new_type: this.toType,
+    };
 
-      this.set("startingMigration", true);
+    this.set("startingMigration", true);
 
-      Rating.migrate(data)
-        .then((result) => {
-          if (result.success) {
-            this.set("migrationMessage", "admin.ratings.migrate.started");
-          } else {
-            this.set(
-              "migrationMessage",
-              "admin.ratings.error.migration_failed_to_start"
-            );
-          }
-        })
-        .finally(() => this.set("startingMigration", false));
-    },
+    Rating.migrate(data)
+      .then((result) => {
+        if (result.success) {
+          this.set("migrationMessage", "admin.ratings.migrate.started");
+        } else {
+          this.set(
+            "migrationMessage",
+            "admin.ratings.error.migration_failed_to_start"
+          );
+        }
+      })
+      .finally(() => this.set("startingMigration", false));
   },
 });

--- a/assets/javascripts/discourse/templates/components/rating-destroy.hbs
+++ b/assets/javascripts/discourse/templates/components/rating-destroy.hbs
@@ -9,7 +9,7 @@
 }}
 
 {{d-button
-  action="destroyRatings"
+  action=(action this.destroyRatings)
   label="admin.ratings.destroy.btn"
   disabled=destroyDisabled
 }}

--- a/assets/javascripts/discourse/templates/components/rating-migrate.hbs
+++ b/assets/javascripts/discourse/templates/components/rating-migrate.hbs
@@ -17,7 +17,7 @@
 }}
 
 {{d-button
-  action="migrate"
+  action=(action this.migrate)
   label="admin.ratings.migrate.btn"
   disabled=migrateDisabled
 }}


### PR DESCRIPTION
Using a string for the action of a `DButton` is deprecated, moreover due to a bug in the deprecation banner this was causing a crash on the `/admin/plugins/ratings` page. The simplest fix was to move to the newer pattern.