### PR TITLE
FIX: Prevent DestroyOldHiddenPosts from failing when there are orphaned posts

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -132,7 +132,7 @@ after_initialize do
   ::PostRevisor.prepend PostRevisorRatingsExtension
 
   add_to_class(:post, :ratings) do
-    DiscourseRatings::Rating.build_model_list(custom_fields, topic.rating_types)
+    DiscourseRatings::Rating.build_model_list(custom_fields, topic&.rating_types || [])
   end
 
   add_to_class(:post, :rated_types) { ratings.select { |r| r.weight > 0 }.map(&:type) }

--- a/spec/extensions/post_revisor_spec.rb
+++ b/spec/extensions/post_revisor_spec.rb
@@ -25,4 +25,11 @@ describe PostRevisor do
 
     expect(rating_post.ratings[0].value).to eq(3.0)
   end
+
+  it "does not error out if post's topic has been deleted first" do
+    rating_post.topic.destroy
+    rating_post.reload
+
+    expect { rating_post.ratings }.not_to raise_error
+  end
 end


### PR DESCRIPTION
Attempting to serialize a post without a topic will cause an issue now when trying to derive its ratings.